### PR TITLE
[FIX] First resize bug in Firefox

### DIFF
--- a/jQuery.resizableColumns.js
+++ b/jQuery.resizableColumns.js
@@ -4,11 +4,9 @@
       var resizingPosX = 0;
       var _table = $(this);
       var _thead = $(this).find('thead');
-
-      _table.innerWidth(_table.innerWidth());
+        
       _thead.find('th').each(function() {
         $(this).css('position', 'relative');
-        $(this).innerWidth($(this).innerWidth());
         if ($(this).is(':not(:last-child)')) $(this).append("<div class='resizer' style='position:absolute;top:0px;right:-3px;bottom:0px;width:6px;z-index:999;background:transparent;cursor:col-resize'></div>");
       })
 


### PR DESCRIPTION
When the columns are resized for the first time causes the columns to shift.

![image](https://user-images.githubusercontent.com/10028499/52269457-6cb4a500-293e-11e9-87cf-c719f7051477.png)

This occurs in Firefox (65.0) but in Chrome (71.0.3578.98) it doesn't seem a problem

cc: @Tardo 